### PR TITLE
Adding region_name to assume_role

### DIFF
--- a/source/Tools Integration/automation_packages/ADS/0-ADS-AgentInstall/0-ADS-AgentInstall.py
+++ b/source/Tools Integration/automation_packages/ADS/0-ADS-AgentInstall/0-ADS-AgentInstall.py
@@ -46,7 +46,7 @@ def assume_role(account_id, region):
   try:
     user = sts_client.get_caller_identity()['Arn']
     sessionname = user.split('/')[1]
-    response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname)
+    response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname, region_name=region)
     credentials = response['Credentials']
     session = boto3.Session(
       region_name = region,

--- a/source/Tools Integration/automation_packages/ADS/1-ADS-AgentUninstall/1-ADS-AgentUninstall.py
+++ b/source/Tools Integration/automation_packages/ADS/1-ADS-AgentUninstall/1-ADS-AgentUninstall.py
@@ -46,7 +46,7 @@ def assume_role(account_id, region):
   try:
     user = sts_client.get_caller_identity()['Arn']
     sessionname = user.split('/')[1]
-    response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname)
+    response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname, region_name=region)
     credentials = response['Credentials']
     session = boto3.Session(
       region_name = region,

--- a/source/Tools Integration/mgn/MGN-automation-scripts/1-AgentInstall/1-AgentInstall.py
+++ b/source/Tools Integration/mgn/MGN-automation-scripts/1-AgentInstall/1-AgentInstall.py
@@ -58,7 +58,7 @@ def assume_role(account_id, region):
   try:
     user = sts_client.get_caller_identity()['Arn']
     sessionname = user.split('/')[1]
-    response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname)
+    response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname, region_name=region)
     credentials = response['Credentials']
     session = boto3.Session(
       region_name = region,

--- a/source/Tools Integration/mgn/MGN-automation-scripts/2-Verify-replication/2-Verify-replication.py
+++ b/source/Tools Integration/mgn/MGN-automation-scripts/2-Verify-replication/2-Verify-replication.py
@@ -49,7 +49,7 @@ def assume_role(account_id, region):
     try:
         user = sts_client.get_caller_identity()['Arn']
         sessionname = user.split('/')[1]
-        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname)
+        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname, region_name=region)
         credentials = response['Credentials']
         session = boto3.Session(
             region_name = region,

--- a/source/Tools Integration/mgn/MGN-automation-scripts/3-Verify-instance-status/3-Verify-instance-status.py
+++ b/source/Tools Integration/mgn/MGN-automation-scripts/3-Verify-instance-status/3-Verify-instance-status.py
@@ -49,7 +49,7 @@ def assume_role(account_id, region):
     try:
         user = sts_client.get_caller_identity()['Arn']
         sessionname = user.split('/')[1]
-        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname)
+        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname, region_name=region)
         credentials = response['Credentials']
         session = boto3.Session(
             region_name = region,

--- a/source/Tools Integration/mgn/MGN-automation-scripts/4-Get-instance-IP/4-Get-instance-IP.py
+++ b/source/Tools Integration/mgn/MGN-automation-scripts/4-Get-instance-IP/4-Get-instance-IP.py
@@ -42,7 +42,7 @@ def assume_role(account_id, region):
     try:
         user = sts_client.get_caller_identity()['Arn']
         sessionname = user.split('/')[1]
-        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname)
+        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname, region_name=region)
         credentials = response['Credentials']
         session = boto3.Session(
             region_name = region,

--- a/source/Tools Integration/mgn/MGN-automation-scripts/5-Post-Cutover-Validations/5-post_cutover_validations.py
+++ b/source/Tools Integration/mgn/MGN-automation-scripts/5-Post-Cutover-Validations/5-post_cutover_validations.py
@@ -80,7 +80,7 @@ def assume_role(account_id, region):
     try:
         user = sts_client.get_caller_identity()['Arn']
         sessionname = user.split('/')[1]
-        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname)
+        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname, region_name=region)
         credentials = response['Credentials']
         session = boto3.Session(
             region_name = region,

--- a/source/Tools Integration/mgn/lambdas/lambda_mgn.py
+++ b/source/Tools Integration/mgn/lambdas/lambda_mgn.py
@@ -108,7 +108,7 @@ def assume_role(account_id):
         user = sts_client.get_caller_identity()['Arn']
         log.info('Logged in as: ' + user)
         sessionname = user.split('/')[1]
-        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname)
+        response = sts_client.assume_role(RoleArn=role_arn, RoleSessionName=sessionname, region_name=region)
         credentials = response['Credentials']
         return credentials
     except botocore.exceptions.ClientError as e:


### PR DESCRIPTION
To fix issue with regional sts endpoints, adding region_name to all assume_role invokations.